### PR TITLE
Add Telescope keymaps for common searches

### DIFF
--- a/nvim/nvim/lua/plugins/telescope.lua
+++ b/nvim/nvim/lua/plugins/telescope.lua
@@ -1,5 +1,12 @@
 return {
     'nvim-telescope/telescope.nvim',
     tag = '0.1.8',
-    dependencies = { 'nvim-lua/plenary.nvim' }
+    dependencies = { 'nvim-lua/plenary.nvim' },
+    config = function()
+        local builtin = require('telescope.builtin')
+        vim.keymap.set('n', '<leader>ff', builtin.find_files, { desc = 'Telescope find files' })
+        vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live grep' })
+        vim.keymap.set('n', '<leader>fb', builtin.buffers, { desc = 'Telescope buffers' })
+        vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc = 'Telescope help tags' })
+    end,
 }


### PR DESCRIPTION
## Summary
- add a configuration callback for telescope.nvim
- define leader key mappings for frequently used Telescope pickers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee57e007408323b43384e834cc370b